### PR TITLE
Add email notification step

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Set date
+      run: echo "DATE=$(date -u '+%Y-%m-%d')" >> $GITHUB_ENV
     - name: Install dependencies
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -39,3 +41,16 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Send email
+      if: ${{ secrets.RECIPIENT_EMAIL != '' }}
+      uses: dawidd6/action-send-mail@v3
+      with:
+        server_address: ${{ secrets.SMTP_SERVER }}
+        server_port: ${{ secrets.SMTP_PORT }}
+        username: ${{ secrets.SMTP_USERNAME }}
+        password: ${{ secrets.SMTP_PASSWORD }}
+        subject: "Daily arXiv Summary"
+        to: ${{ secrets.RECIPIENT_EMAIL }}
+        from: ${{ secrets.SMTP_USERNAME }}
+        secure: true
+        attachments: "data/${{ env.DATE }}.md"

--- a/README.md
+++ b/README.md
@@ -11,19 +11,25 @@ Otherwise, you can directly use this repo. Please star it if you like :)
 2. Go to: your-own-repo -> Settings -> Secrets and variables -> Actions
 3. Go to Secrets. Secrets are encrypted and are used for sensitive data
 4. Create two repository secrets named `OPENAI_API_KEY` and `OPENAI_BASE_URL`, and input corresponding values.
-5. Go to Variables. Variables are shown as plain text and are used for non-sensitive data
-6. Create the following repository variables:
+5. To enable email notifications, add the following repository secrets:
+   - `SMTP_SERVER`: address of your SMTP server
+   - `SMTP_PORT`: port of your SMTP server, such as `465`
+   - `SMTP_USERNAME`: username of the email account used to send messages
+   - `SMTP_PASSWORD`: password or app token for the email account
+   - `RECIPIENT_EMAIL`: address that will receive the daily Markdown
+6. Go to Variables. Variables are shown as plain text and are used for non-sensitive data
+7. Create the following repository variables:
    1. `CATEGORIES`: separate the categories with ",", such as "cs.CL, cs.CV"
    2. `LANGUAGE`: such as "Chinese" or "English"
    3. `MODEL_NAME`: such as "deepseek-chat"
    4. `EMAIL`: your email for push to github
    5. `NAME`: your name for push to github
    6. `RESEARCH_INTERESTS`: keywords used to sort papers. A LLM ranks each paper by how well it matches these interests, e.g. `AIGC, 视频生成, 视频编辑, Diffusion`
-7. Go to your-own-repo -> Actions -> arXiv-daily-ai-enhanced
-8. You can manually click **Run workflow** to test if it works well (it may takes about one hour). 
+8. Go to your-own-repo -> Actions -> arXiv-daily-ai-enhanced
+9. You can manually click **Run workflow** to test if it works well (it may takes about one hour).
 By default, this action will automatically run every day
 You can modify it in `.github/workflows/run.yml`
-9. If you wish to modify the content in `README.md`, do not directly edit README.md. You should edit `template.md`.
+10. If you wish to modify the content in `README.md`, do not directly edit README.md. You should edit `template.md`.
 
 # Content
 [2025-06-04](data/2025-06-04.md)

--- a/template.md
+++ b/template.md
@@ -11,19 +11,25 @@ Otherwise, you can directly use this repo. Please star it if you like :)
 2. Go to: your-own-repo -> Settings -> Secrets and variables -> Actions
 3. Go to Secrets. Secrets are encrypted and are used for sensitive data
 4. Create two repository secrets named `OPENAI_API_KEY` and `OPENAI_BASE_URL`, and input corresponding values.
-5. Go to Variables. Variables are shown as plain text and are used for non-sensitive data
-6. Create the following repository variables:
+5. To enable email notifications, add the following repository secrets:
+   - `SMTP_SERVER`: address of your SMTP server
+   - `SMTP_PORT`: port of your SMTP server, such as `465`
+   - `SMTP_USERNAME`: username of the email account used to send messages
+   - `SMTP_PASSWORD`: password or app token for the email account
+   - `RECIPIENT_EMAIL`: address that will receive the daily Markdown
+6. Go to Variables. Variables are shown as plain text and are used for non-sensitive data
+7. Create the following repository variables:
    1. `CATEGORIES`: separate the categories with ",", such as "cs.CL, cs.CV"
    2. `LANGUAGE`: such as "Chinese" or "English"
    3. `MODEL_NAME`: such as "deepseek-chat"
    4. `EMAIL`: your email for push to github
    5. `NAME`: your name for push to github
    6. `RESEARCH_INTERESTS`: keywords used to sort papers. A LLM ranks each paper by how well it matches these interests, e.g. `AIGC, 视频生成, 视频编辑, Diffusion`
-7. Go to your-own-repo -> Actions -> arXiv-daily-ai-enhanced
-8. You can manually click **Run workflow** to test if it works well (it may takes about one hour). 
+8. Go to your-own-repo -> Actions -> arXiv-daily-ai-enhanced
+9. You can manually click **Run workflow** to test if it works well (it may takes about one hour).
 By default, this action will automatically run every day
 You can modify it in `.github/workflows/run.yml`
-9. If you wish to modify the content in `README.md`, do not directly edit README.md. You should edit `template.md`.
+10. If you wish to modify the content in `README.md`, do not directly edit README.md. You should edit `template.md`.
 
 # Content
 {readme_content}


### PR DESCRIPTION
## Summary
- add secret SMTP settings to README instructions
- send generated Markdown via email in GitHub workflow

## Testing
- `python update_readme.py`

------
https://chatgpt.com/codex/tasks/task_b_6841bd000bf4832c8babdafa7f5d875a